### PR TITLE
Fix missing lib on Moodle v4.5

### DIFF
--- a/report_download.php
+++ b/report_download.php
@@ -73,7 +73,6 @@ if (!isset($plugins[$format]) || !$plugins[$format]->is_enabled()) {
 }
 
 // Otherwise, everything's good. Proceed with the processing.
-require_once($CFG->dirroot . '/lib/dataformatlib.php');
 
 // Fetch the user.
 $touser = core_user::get_user($touserid);


### PR DESCRIPTION
## Environment
- Moodle version v4.5

## Summary
The `dataformatlib.php` file has been removed since Moodle v4.4. Currently, it throws error when the user try to Download feedback report.

## Download feedback report as...
![Screenshot From 2025-04-24 16-39-45](https://github.com/user-attachments/assets/279a218d-39c8-48da-b836-49e12e34422b)

## The Error
![Screenshot From 2025-04-24 16-40-06](https://github.com/user-attachments/assets/2444b9fb-533b-473b-abef-726f0175ac45)

## Fixes
- Remove the deprecated `dataformatlib.php` import in the `report_download.php` file.

With this fix, we can now download the report in Moodle v4.5. Really appreciate for your feedback. Thank you.
![Screenshot From 2025-04-24 16-50-40](https://github.com/user-attachments/assets/3d9a7d0a-91a5-48c6-83bb-88ef59252921)
